### PR TITLE
Updating status for CSS Grid in Safari TP

### DIFF
--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -174,7 +174,7 @@
       "9":"p",
       "9.1":"p",
       "10":"p",
-      "TP":"n d #4"
+      "TP":"y"
     },
     "opera":{
       "9":"n",
@@ -282,7 +282,6 @@
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
     "2":"Partial support in IE refers to supporting an [older version](http://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/) of the specification.",
     "3":"Enabled in Firefox through the `layout.css.grid.enabled ` flag",
-    "4":"Can be enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":0,
   "usage_perc_a":6,

--- a/features-json/css-grid.json
+++ b/features-json/css-grid.json
@@ -174,7 +174,7 @@
       "9":"p",
       "9.1":"p",
       "10":"p",
-      "TP":"y"
+      "TP":"y d #4"
     },
     "opera":{
       "9":"n",
@@ -282,6 +282,7 @@
     "1":"Enabled in Chrome through the \"experimental Web Platform features\" flag in chrome://flags",
     "2":"Partial support in IE refers to supporting an [older version](http://www.w3.org/TR/2011/WD-css3-grid-layout-20110407/) of the specification.",
     "3":"Enabled in Firefox through the `layout.css.grid.enabled ` flag",
+    "4":"Can be disabled or enabled via the \"Experimental Features\" developer menu"
   },
   "usage_perc_y":0,
   "usage_perc_a":6,


### PR DESCRIPTION
CSS Grid is now enabled by default in Safari Technical Preview. 

There is still a setting in the drop-down menu where people can toggle it on and off, but if you install Safari TP fresh from a download, it's now on.